### PR TITLE
Handle request ReadTimeouts in etcd_watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NMOS Query API Implementation Changelog
 
+## 0.5.1
+
+- Fix bug that causes "Read timed out." messages to be logged when communicating with etcd in normal circumstances
+
 ## 0.5.0
 - Add config option to enable/disable mDNS announcement
 

--- a/nmosquery/etcd_watch.py
+++ b/nmosquery/etcd_watch.py
@@ -129,7 +129,7 @@ class EtcdEventQueue(object):
                 next_index_param = "&waitIndex={}".format(current_index + 1)
                 req = requests.get(self._long_poll_url + next_index_param, proxies={'http': ''}, timeout=20)
 
-            except socket.timeout:
+            except (socket.timeout, requests.ReadTimeout):
                 # Get a new wait index to watch from by querying /resource
                 self._logger.writeDebug("Timeout waiting on long-poll. Refreshing waitIndex...")
                 current_index = self._get_index(current_index)

--- a/rpm/registryquery.spec
+++ b/rpm/registryquery.spec
@@ -1,7 +1,7 @@
 %global module_name registryquery
 
 Name: 			python-%{module_name}
-Version: 		0.5.0
+Version: 		0.5.1
 Release: 		1%{?dist}
 License: 		Internal Licence
 Summary: 		API interface to IP Studio service registry

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ packages_required = [
 ]
 
 setup(name="registryquery",
-      version="0.5.0",
+      version="0.5.1",
       description="BBC implementation of an AMWA NMOS Query API",
       url='https://github.com/bbc/nmos-query',
       author='Peter Brightwell',


### PR DESCRIPTION
Often logs are filled with lines like:

```
2019-01-04 10:49:09,756 WARN  python.regquery.regquery.etcd_watch Could not contact etcd: HTTPConnectionPool(host='localhost', port=4001): Read timed out.
```

As far as I can tell, requests throws a ReadTimeout exception rather than a socket.timeout exception, so this handles that case as intended.