### PR TITLE
grainevent: fix breach of spec in grain construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Query API Implementation Changelog
 
+## 0.5.4
+- Fix bug in websocket message format
+
 ## 0.5.3
 - Ensure only wss:// connections can be created in secure mode
 

--- a/nmosquery/common/query.py
+++ b/nmosquery/common/query.py
@@ -119,7 +119,7 @@ class QueryCommon(object):
     # summarise service in a presentable way
     def _summarise(self, json_repr):
         if not json_repr:
-            return {}
+            return None
 
         removals = (x for x in json_repr.keys() if x.startswith("@_"))
         for key in removals:

--- a/nmosquery/common/query.py
+++ b/nmosquery/common/query.py
@@ -240,10 +240,10 @@ class QueryCommon(object):
             event.clearGrains()
             if not self._matches_args(s_pn_obj, s.params):
                 # Didn't previously match filter, so should be returned
-                event.addGrainFromObj(pre_obj={}, post_obj=n_obj)
+                event.addGrainFromObj(pre_obj=None, post_obj=n_obj)
             elif not self._matches_args(s_n_obj, s.params):
                 # Doesn't match filter any longer, so shouldn't be returned
-                event.addGrainFromObj(pre_obj=s_pn_obj, post_obj={})
+                event.addGrainFromObj(pre_obj=s_pn_obj, post_obj=None)
             else:
                 event.addGrainFromObj(pre_obj=s_pn_obj, post_obj=s_n_obj)
             s.notify_subscribers(event.obj())
@@ -270,6 +270,6 @@ class QueryCommon(object):
 
             event.flow_id = s.uuid
             event.clearGrains()
-            event.addGrainFromObj(pre_obj=s_pn_obj, post_obj={})
+            event.addGrainFromObj(pre_obj=s_pn_obj, post_obj=None)
 
             s.notify_subscribers(event.obj())

--- a/nmosquery/grainevent.py
+++ b/nmosquery/grainevent.py
@@ -24,18 +24,15 @@ class GrainEvent(object):
         self.topic = ''
 
     def addGrainFromObj(self, pre_obj=None, post_obj=None):
-        if pre_obj is None:
-            pre_obj = {}
-        if post_obj is None:
-            post_obj = {}
-        uid = pre_obj.get('id', '')
-        if uid == '':
+        uid = ''
+        grain = {}
+        if pre_obj is not None:
+            uid = pre_obj.get('id', '')
+            grain["pre"] = pre_obj
+        if post_obj is not None:
             uid = post_obj.get('id', '')
-        grain = {
-            "path": uid,
-            "pre": pre_obj,
-            "post": post_obj
-        }
+            grain["post"] = post_obj
+        grain["path"] = uid
 
         self.grains.append(grain)
 

--- a/rpm/registryquery.spec
+++ b/rpm/registryquery.spec
@@ -1,7 +1,7 @@
 %global module_name registryquery
 
 Name: 			python-%{module_name}
-Version: 		0.5.3
+Version: 		0.5.4
 Release: 		1%{?dist}
 License: 		Internal Licence
 Summary: 		API interface to IP Studio service registry

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ packages_required = [
 ]
 
 setup(name="registryquery",
-      version="0.5.3",
+      version="0.5.4",
       description="BBC implementation of an AMWA NMOS Query API",
       url='https://github.com/bbc/nmos-query',
       author='Peter Brightwell',

--- a/tests/v1_0/test_query.py
+++ b/tests/v1_0/test_query.py
@@ -108,8 +108,8 @@ class TestQuery(unittest.TestCase):
 
     def test_summarise(self):
         """ it should leave structure alone """
-        self.assertEqual({}, self.query._summarise({}))
-        self.assertEqual({}, self.query._summarise(None))
+        self.assertEqual(None, self.query._summarise({}))
+        self.assertEqual(None, self.query._summarise(None))
         self.assertEqual({"foo": 1, "bar": 2}, self.query._summarise({"foo": 1, "bar": 2}))
 
     def test_matches_path(self):

--- a/tests/v1_1/test_query.py
+++ b/tests/v1_1/test_query.py
@@ -107,8 +107,8 @@ class TestQuery(unittest.TestCase):
 
     def test_summarise(self):
         """ it should leave structure alone """
-        self.assertEqual({}, self.query._summarise({}))
-        self.assertEqual({}, self.query._summarise(None))
+        self.assertEqual(None, self.query._summarise({}))
+        self.assertEqual(None, self.query._summarise(None))
         self.assertEqual({"foo": 1, "bar": 2}, self.query._summarise({"foo": 1, "bar": 2}))
 
     def test_matches_path(self):

--- a/tests/v1_2/test_query.py
+++ b/tests/v1_2/test_query.py
@@ -107,8 +107,8 @@ class TestQuery(unittest.TestCase):
 
     def test_summarise(self):
         """ it should leave structure alone """
-        self.assertEqual({}, self.query._summarise({}))
-        self.assertEqual({}, self.query._summarise(None))
+        self.assertEqual(None, self.query._summarise({}))
+        self.assertEqual(None, self.query._summarise(None))
         self.assertEqual({"foo": 1, "bar": 2}, self.query._summarise({"foo": 1, "bar": 2}))
 
     def test_matches_path(self):

--- a/tests/v1_3/test_query.py
+++ b/tests/v1_3/test_query.py
@@ -107,8 +107,8 @@ class TestQuery(unittest.TestCase):
 
     def test_summarise(self):
         """ it should leave structure alone """
-        self.assertEqual({}, self.query._summarise({}))
-        self.assertEqual({}, self.query._summarise(None))
+        self.assertEqual(None, self.query._summarise({}))
+        self.assertEqual(None, self.query._summarise(None))
         self.assertEqual({"foo": 1, "bar": 2}, self.query._summarise({"foo": 1, "bar": 2}))
 
     def test_matches_path(self):


### PR DESCRIPTION
This is an error in the implementation of the spec, but it creates a potentially breaking change for clients of the API if they made use of the keys being removed. May require a major version bump as a result.