### PR TITLE
etcdwatch: fix error when using early versions of requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # NMOS Query API Implementation Changelog
 
-## 0.5.1
+## 0.5.2
+- Fix compatibility with older versions of Requests which define exceptions differently
 
+## 0.5.1
 - Fix bug that causes "Read timed out." messages to be logged when communicating with etcd in normal circumstances
 
 ## 0.5.0

--- a/nmosquery/etcd_watch.py
+++ b/nmosquery/etcd_watch.py
@@ -129,7 +129,7 @@ class EtcdEventQueue(object):
                 next_index_param = "&waitIndex={}".format(current_index + 1)
                 req = requests.get(self._long_poll_url + next_index_param, proxies={'http': ''}, timeout=20)
 
-            except (socket.timeout, requests.ReadTimeout):
+            except (socket.timeout, requests.exceptions.ReadTimeout):
                 # Get a new wait index to watch from by querying /resource
                 self._logger.writeDebug("Timeout waiting on long-poll. Refreshing waitIndex...")
                 current_index = self._get_index(current_index)

--- a/rpm/registryquery.spec
+++ b/rpm/registryquery.spec
@@ -1,7 +1,7 @@
 %global module_name registryquery
 
 Name: 			python-%{module_name}
-Version: 		0.5.1
+Version: 		0.5.2
 Release: 		1%{?dist}
 License: 		Internal Licence
 Summary: 		API interface to IP Studio service registry

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ packages_required = [
 ]
 
 setup(name="registryquery",
-      version="0.5.1",
+      version="0.5.2",
       description="BBC implementation of an AMWA NMOS Query API",
       url='https://github.com/bbc/nmos-query',
       author='Peter Brightwell',


### PR DESCRIPTION
I've had to change this a little as the older version of requests we package for debian doesn't seem to allow the exceptions to be imported from the main module.