### PR TITLE
query: fix bug when first adding a resource which matches a filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Query API Implementation Changelog
 
+## 0.5.6
+- Fix bug causing some missing messages via WebSockets
+
 ## 0.5.5
 - Fix bug preventing use of priorities between 1 and 99
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.5.6
 - Fix bug causing some missing messages via WebSockets
+- Fix bugs responding when multiple similar WebSockets are open
 
 ## 0.5.5
 - Fix bug preventing use of priorities between 1 and 99

--- a/nmosquery/common/query.py
+++ b/nmosquery/common/query.py
@@ -19,7 +19,7 @@ import os
 import socket
 import string
 import uuid
-import re
+import copy
 
 import nmosquery.util as util
 import requests
@@ -34,6 +34,7 @@ from nmosquery import version_transforms
 
 reg = {'host': 'localhost', 'port': 4001}
 WS_PORT = 8870
+
 
 class QueryCommon(object):
 
@@ -80,14 +81,15 @@ class QueryCommon(object):
                 if self._matches_path(k, pattern):
                     downgrade_ver = None
                     if args and "query.downgrade" in args:
-                         downgrade_ver = args["query.downgrade"]
+                        downgrade_ver = args["query.downgrade"]
 
                     # Downgrade / convert any mis-versioned objects as required
                     resource_type = util.get_resourcetypes(k).replace("/", "")
                     json_repr = None
                     if resource_type != "":
                         json_repr = json.loads(v)
-                        json_repr = version_transforms.convert(json_repr, resource_type, self.api_version, downgrade_ver)
+                        json_repr = version_transforms.convert(copy.deepcopy(json_repr), resource_type,
+                                                               self.api_version, downgrade_ver)
 
                     # If nothing could be downgraded, skip over the object
                     if not json_repr:
@@ -227,8 +229,10 @@ class QueryCommon(object):
             if socket.params and "query.downgrade" in socket.params:
                 downgrade_ver = socket.params["query.downgrade"]
 
-            socket_post_obj = version_transforms.convert(post_obj, event.topic.replace("/", ""), self.api_version, downgrade_ver)
-            socket_pre_obj = version_transforms.convert(pre_obj, event.topic.replace("/", ""), self.api_version, downgrade_ver)
+            socket_post_obj = version_transforms.convert(copy.deepcopy(post_obj), event.topic.replace("/", ""),
+                                                         self.api_version, downgrade_ver)
+            socket_pre_obj = version_transforms.convert(copy.deepcopy(pre_obj), event.topic.replace("/", ""),
+                                                        self.api_version, downgrade_ver)
 
             if not socket_post_obj and not socket_pre_obj:
                 continue
@@ -261,7 +265,8 @@ class QueryCommon(object):
             if socket.params and "query.downgrade" in socket.params:
                 downgrade_ver = socket.params["query.downgrade"]
 
-            socket_pre_obj = version_transforms.convert(pre_obj, event.topic.replace("/", ""), self.api_version, downgrade_ver)
+            socket_pre_obj = version_transforms.convert(copy.deepcopy(pre_obj), event.topic.replace("/", ""),
+                                                        self.api_version, downgrade_ver)
 
             if not socket_pre_obj:
                 continue

--- a/nmosquery/common/query.py
+++ b/nmosquery/common/query.py
@@ -255,7 +255,7 @@ class QueryCommon(object):
         event.source_id = self.gen_source_id()
         event.topic = util.get_resourcetypes(path)
         for socket in sockets:
-            self.logger.writeDebug('next ws' + socket.ws_href)
+            self.logger.writeDebug('next ws ' + socket.ws_href)
 
             downgrade_ver = None
             if socket.params and "query.downgrade" in socket.params:

--- a/nmosquery/common/query.py
+++ b/nmosquery/common/query.py
@@ -132,7 +132,7 @@ class QueryCommon(object):
         Process a response from a GET long-poll on etcd (watch).
         `response' is a dict, decoded from JSON.
         """
-        self.logger.writeDebug('process response {}'.format(response))
+        self.logger.writeDebug('process response {} {}'.format(self.api_version, response))
         if response['action'] == 'set' or response['action'] == 'delete':
             unpacked = etcd_unpack(response)
             for k, v in unpacked.items():
@@ -213,7 +213,7 @@ class QueryCommon(object):
             self.logger.writeError('Exception in do_sync: {}'.format(err))
 
     def do_sup(self, path, pre_obj, post_obj):
-        self.logger.writeDebug('do_sup {}'.format(path))
+        self.logger.writeDebug('do_sup {} {}'.format(self.api_version, path))
         if cmp(post_obj, pre_obj) == 0:
             return
         sockets = self.query_sockets.find_socks(path=path, obj=post_obj, p_obj=pre_obj)
@@ -249,7 +249,7 @@ class QueryCommon(object):
             socket.notify_subscribers(event.obj())
 
     def do_sdown(self, path, pre_obj, post_obj):
-        self.logger.writeDebug('do_sdown {}'.format(path))
+        self.logger.writeDebug('do_sdown {} {}'.format(self.api_version, path))
         sockets = self.query_sockets.find_socks(path=path, obj=post_obj, p_obj=pre_obj)
         event = GrainEvent()
         event.source_id = self.gen_source_id()

--- a/nmosquery/common/query.py
+++ b/nmosquery/common/query.py
@@ -238,10 +238,10 @@ class QueryCommon(object):
 
             event.flow_id = s.uuid
             event.clearGrains()
-            if not self._matches_args(s_pn_obj, s.params):
+            if s_pn_obj is None or not self._matches_args(s_pn_obj, s.params):
                 # Didn't previously match filter, so should be returned
                 event.addGrainFromObj(pre_obj=None, post_obj=n_obj)
-            elif not self._matches_args(s_n_obj, s.params):
+            elif s_n_obj is None or not self._matches_args(s_n_obj, s.params):
                 # Doesn't match filter any longer, so shouldn't be returned
                 event.addGrainFromObj(pre_obj=s_pn_obj, post_obj=None)
             else:

--- a/nmosquery/common/query.py
+++ b/nmosquery/common/query.py
@@ -244,7 +244,7 @@ class QueryCommon(object):
             event.clearGrains()
             if socket_pre_obj is None or not self._matches_args(socket_pre_obj, socket.params):
                 # Didn't previously match filter, so should be returned
-                event.addGrainFromObj(pre_obj=None, post_obj=post_obj)
+                event.addGrainFromObj(pre_obj=None, post_obj=socket_post_obj)
             elif socket_post_obj is None or not self._matches_args(socket_post_obj, socket.params):
                 # Doesn't match filter any longer, so shouldn't be returned
                 event.addGrainFromObj(pre_obj=socket_pre_obj, post_obj=None)

--- a/nmosquery/common/querysockets.py
+++ b/nmosquery/common/querysockets.py
@@ -126,32 +126,25 @@ class QuerySocketsCommon(object):
     # Return ws subscribers that are interested in given object
     def find_socks(self, path=None, obj=None, p_obj=None):
         retval = []
-
-        if obj != None:
-            # find subscribers for given node
-
-            # eg. path=/dest, args=[label:123]
-
-            # obj = obj[obj.keys()[0]]
-            uid = obj.get('uuid', None)
-            for s in self.sockets:
-                sock_path = util.translate_resourcetypes(s.resource_path)
-                matched = True
-                if uid == s.uuid:
-                    matched = True
-                elif sock_path:
-                    if sock_path in path:
+        # find subscribers for given node
+        # eg. path=/dest, args=[label:123]
+        # obj = obj[obj.keys()[0]]
+        for s in self.sockets:
+            sock_path = util.translate_resourcetypes(s.resource_path)
+            matched = False
+            if sock_path:
+                if sock_path in path:
+                    if obj:
                         matched = self._check_args(s, obj)
-                        if p_obj and not matched:
-                            matched = self._check_args(s, p_obj)
-                    else:
-                        matched = False
-                elif not sock_path:   # resource path not defined
-                    matched = self._check_args(s, obj)
                     if p_obj and not matched:
                         matched = self._check_args(s, p_obj)
-                if matched:
-                    retval.append(s)
+            else:  # resource path not defined
+                if obj:
+                    matched = self._check_args(s, obj)
+                if p_obj and not matched:
+                    matched = self._check_args(s, p_obj)
+            if matched:
+                retval.append(s)
         return retval
 
     def _check_args(self, s, obj):

--- a/nmosquery/common/routes.py
+++ b/nmosquery/common/routes.py
@@ -23,10 +23,13 @@ from nmosquery.common.query import QueryCommon
 
 class RoutesCommon(object):
 
-    def __init__(self, logger, config, api_version="v1.0"):
+    def __init__(self, logger, config, api_version="v1.0", query=None):
         self.logger = logger
         self.config = config
-        self.query = QueryCommon(logger=self.logger)
+        if not query:
+            self.query = QueryCommon(logger=self.logger)
+        else:
+            self.query = query
         self.on_websocket_connect = self.websocket_opened
         self.api_version = api_version
 

--- a/nmosquery/v1_0/routes.py
+++ b/nmosquery/v1_0/routes.py
@@ -18,5 +18,5 @@ from nmosquery.v1_0.query import Query
 
 class Routes(RoutesCommon):
     def __init__(self, logger, config):
-        super(Routes, self).__init__(logger, config, "v1.0")
-        self.query = Query(logger=logger)
+        query = Query(logger=logger)
+        super(Routes, self).__init__(logger, config, "v1.0", query)

--- a/nmosquery/v1_1/routes.py
+++ b/nmosquery/v1_1/routes.py
@@ -18,5 +18,5 @@ from nmosquery.v1_1.query import Query
 
 class Routes(RoutesCommon):
     def __init__(self, logger, config):
-        super(Routes, self).__init__(logger, config, "v1.1")
-        self.query = Query(logger=logger)
+        query = Query(logger=logger)
+        super(Routes, self).__init__(logger, config, "v1.1", query)

--- a/nmosquery/v1_2/routes.py
+++ b/nmosquery/v1_2/routes.py
@@ -18,5 +18,5 @@ from nmosquery.v1_2.query import Query
 
 class Routes(RoutesCommon):
     def __init__(self, logger, config):
-        super(Routes, self).__init__(logger, config, "v1.2")
-        self.query = Query(logger=logger)
+        query = Query(logger=logger)
+        super(Routes, self).__init__(logger, config, "v1.2", query)

--- a/nmosquery/v1_3/routes.py
+++ b/nmosquery/v1_3/routes.py
@@ -18,5 +18,5 @@ from nmosquery.v1_3.query import Query
 
 class Routes(RoutesCommon):
     def __init__(self, logger, config):
-        super(Routes, self).__init__(logger, config, "v1.3")
-        self.query = Query(logger=logger)
+        query = Query(logger=logger)
+        super(Routes, self).__init__(logger, config, "v1.3", query)

--- a/rpm/registryquery.spec
+++ b/rpm/registryquery.spec
@@ -1,7 +1,7 @@
 %global module_name registryquery
 
 Name: 			python-%{module_name}
-Version: 		0.5.5
+Version: 		0.5.6
 Release: 		1%{?dist}
 License: 		Internal Licence
 Summary: 		API interface to IP Studio service registry

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ packages_required = [
 ]
 
 setup(name="registryquery",
-      version="0.5.5",
+      version="0.5.6",
       description="BBC implementation of an AMWA NMOS Query API",
       url='https://github.com/bbc/nmos-query',
       author='Peter Brightwell',


### PR DESCRIPTION
Fixes an uncaught exception relating to WebSocket subscriptions when a freshly registered resource is added.