### PR TITLE
etcd: use official default ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Query API Implementation Changelog
 
+## 0.8.0
+- Use official etcd ports
+
 ## 0.7.10
 - Alter executable to run using Python3, alter `stdeb` to replace python 2 package
 

--- a/nmosquery/common/query.py
+++ b/nmosquery/common/query.py
@@ -33,7 +33,7 @@ from ..etcd_util import etcd_unpack # noqa E402
 from ..grainevent import GrainEvent # noqa E402
 from .querysockets import QuerySocketsCommon, QueryFilterCommon # noqa E402
 
-reg = {'host': 'localhost', 'port': 4001}
+reg = {'host': 'localhost', 'port': 2379}
 WS_PORT = 8870
 
 

--- a/nmosquery/etcd_backend.py
+++ b/nmosquery/etcd_backend.py
@@ -45,7 +45,7 @@ def __http(addr, port, method, url, payload=None):
         conn.close()
 
 
-def put(key, value, ttl=None, port=4001):
+def put(key, value, ttl=None, port=2379):
     value = "value={}".format(value)
     if ttl:
         value += "&ttl={}".format(ttl)
@@ -53,5 +53,5 @@ def put(key, value, ttl=None, port=4001):
     return __http("localhost", port, "PUT", "/v2/keys{}".format(key), value)
 
 
-def delete(key, port=4001):
+def delete(key, port=2379):
     return __http("localhost", port, "DELETE", "/v2/keys{}?recursive=true".format(key))

--- a/nmosquery/etcd_watch.py
+++ b/nmosquery/etcd_watch.py
@@ -183,7 +183,7 @@ class EtcdEventQueue(object):
 
 if __name__ == '__main__':
 
-    q = EtcdEventQueue("localhost", 4001)
+    q = EtcdEventQueue("localhost", 2379)
     exist = set()
 
     for event in q.queue:

--- a/nmosquery/service.py
+++ b/nmosquery/service.py
@@ -36,7 +36,7 @@ from nmoscommon.utils import getLocalIP # noqa E402
 from .api import QueryServiceAPI, QUERY_APIVERSIONS # noqa E402
 from .config import config  # noqa E402
 
-reg = {'host': 'localhost', 'port': 4001}
+reg = {'host': 'localhost', 'port': 2379}
 HOST = getLocalIP()
 WS_PORT = 8870
 DNS_SD_HTTP_PORT = 80

--- a/rpm/registryquery.spec
+++ b/rpm/registryquery.spec
@@ -1,7 +1,7 @@
 %global module_name registryquery
 
 Name: 			python-%{module_name}
-Version: 		0.7.8
+Version: 		0.8.0
 Release: 		1%{?dist}
 License: 		Internal Licence
 Summary: 		API interface to IP Studio service registry

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ packages_required = [
 
 setup(
     name="registryquery",
-    version="0.7.10",
+    version="0.8.0",
     description="BBC implementation of an AMWA NMOS Query API",
     url='https://github.com/bbc/nmos-query',
     author='Peter Brightwell',


### PR DESCRIPTION
The repetition is non-ideal, but as we'll be swapping out etcd soon I'm not intending to spend time fixing it.