### PR TITLE
routes: add missing support for Location header in /subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Query API Implementation Changelog
 
+## 0.8.1
+- Add missing Location header for subscriptions
+
 ## 0.8.0
 - Use official etcd ports
 

--- a/rpm/registryquery.spec
+++ b/rpm/registryquery.spec
@@ -1,7 +1,7 @@
 %global module_name registryquery
 
 Name: 			python-%{module_name}
-Version: 		0.8.0
+Version: 		0.8.1
 Release: 		1%{?dist}
 License: 		Internal Licence
 Summary: 		API interface to IP Studio service registry

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ packages_required = [
 
 setup(
     name="registryquery",
-    version="0.8.0",
+    version="0.8.1",
     description="BBC implementation of an AMWA NMOS Query API",
     url='https://github.com/bbc/nmos-query',
     author='Peter Brightwell',


### PR DESCRIPTION
This is a simple fix for a missing header. The fact I end up using jsonify breaks the tests which pass in a mock object, so I still need to resolve that before this is merge-able.